### PR TITLE
Add grid layout DSL with tests and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,39 @@ It felt less work to reimplement the basic features of Clay than extending the c
 
 * I might not need the same performance for TUI layout.
 * There are a couple things that the layout library assume that isn't completely true: text and borders can have a background.
-* The feature requets for a grid and inline wrapper have been held up for a while now and Nick suggest to try it anyway in his [video](https://www.youtube.com/watch?v=by9lQvpvMIc). 
+* The feature requets for a grid and inline wrapper have been held up for a while now and Nick suggest to try it anyway in his [video](https://www.youtube.com/watch?v=by9lQvpvMIc).
+
+## Grid layout
+
+Use the `grid` helper inside any `ui` block to divide a container into rows and columns, then declare `area` blocks to place children into specific cells or spans.
+
+```ruby
+commands = layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+  ui(id: 'main', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+    grid columns: '20 1fr 2fr', rows: '3 1fr 3', gap: 1 do
+      area :header, row: 1, col: :all do
+        text 'Header'
+      end
+
+      area :sidebar, row: 2, col: 1 do
+        text 'Sidebar'
+      end
+
+      area :content, row: 2, col: 2..3 do
+        text 'Main content'
+      end
+
+      area :footer, row: 3, col: :all do
+        text 'Footer'
+      end
+    end
+  end
+end
+```
+
+Tracks are defined by a single space-delimited string. Tokens accept fixed sizes (`'12'`), percentages of the container (`'30%'`), or fractional units (`'1fr'`, `'2fr'`) that share whatever space remains after fixed and percent tracks plus the configured gap. Areas may target a single row/column, a range (`row: 2..4`), or use `:all` to span the full axis. Nested grids work naturally because each `area` behaves like a regular `ui` node once its rectangle is computed.
+
+Run `bin/run examples/grid.rb` to see the interactive demo that renders a header, sidebar, nested content grid, and footer using the DSL above.
 
 ## Build
 

--- a/examples/grid.rb
+++ b/examples/grid.rb
@@ -1,0 +1,58 @@
+Termbox2.init
+
+layout = Panes.init(width: Termbox2.width, height: Termbox2.height)
+
+begin
+  loop do
+    layout.width = Termbox2.width
+    layout.height = Termbox2.height
+
+    commands = layout.build(
+      id: 'root',
+      width: Panes::Sizing.grow,
+      height: Panes::Sizing.grow,
+      border: { all: [:black, :default] }
+    ) do
+      ui(id: 'dashboard', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        grid columns: '20 1fr 2fr', rows: '3 1fr 3', gap: 1 do
+          area :header, row: 1, col: :all, bg_color: :blue, fg_color: :white do
+            text 'Grid header layout'
+          end
+
+          area :sidebar, row: 2, col: 1, bg_color: :red, fg_color: :white do
+            text "Navigation\n- Status\n- Logs"
+          end
+
+          area :main, row: 2, col: 2..3, border: { all: [:black, :default] } do
+            grid columns: '1fr 1fr', rows: '1fr 1fr', gap: 1 do
+              area :stats, row: 1, col: :all, bg_color: :green, fg_color: :black do
+                text 'Nested grid'
+              end
+
+              area :left, row: 2, col: 1, bg_color: :yellow, fg_color: :black do
+                text 'Left pane'
+              end
+
+              area :right, row: 2, col: 2, bg_color: :cyan, fg_color: :black do
+                text 'Right pane'
+              end
+            end
+          end
+
+          area :footer, row: 3, col: :all, bg_color: :white, fg_color: :black do
+            text 'Press q to quit'
+          end
+        end
+      end
+    end
+
+    Panes::TBRender.render_commands(commands, tb: Termbox2)
+    Termbox2.present
+
+    event = Termbox2.peek_event(33)
+    Termbox2.clear
+    break if event && event[:ch] && event[:ch].chr == 'q'
+  end
+ensure
+  Termbox2.shutdown
+end

--- a/mrblib/grid_layout.rb
+++ b/mrblib/grid_layout.rb
@@ -1,0 +1,344 @@
+module Panes
+  class GridLayout
+    Track = Struct.new(:type, :value)
+    AreaAssignment = Struct.new(:node, :row_range, :col_range)
+
+    attr_reader :columns, :rows, :gap
+
+    def initialize(columns:, rows:, gap: 0)
+      @gap = (gap || 0).to_i
+      raise ArgumentError, 'Grid gap must be non-negative' if @gap < 0
+
+      @columns = parse_tracks(columns, :columns)
+      @rows = parse_tracks(rows, :rows)
+
+      if @columns.empty? || @rows.empty?
+        raise ArgumentError, 'Grid requires at least one row and one column'
+      end
+    end
+
+    def track_count(axis)
+      case axis
+      when :columns then columns.length
+      when :rows    then rows.length
+      else 0
+      end
+    end
+
+    def layout(container_width:, container_height:)
+      {
+        columns: layout_columns(container_width),
+        rows:    layout_rows(container_height)
+      }
+    end
+
+    def layout_columns(container_width)
+      layout_axis(columns, container_width, :columns)
+    end
+
+    def layout_rows(container_height)
+      layout_axis(rows, container_height, :rows)
+    end
+
+    def range_length(range)
+      range_end = range.end
+      range_end -= 1 if range.exclude_end?
+      range_end - range.begin + 1
+    end
+
+    def axis_start(layout_axis, index)
+      layout_axis[:offsets][index]
+    end
+
+    def span_size(layout_axis, range)
+      size = 0
+      last_index = normalized_index(range.end, range.exclude_end?)
+      first_index = normalized_index(range.begin)
+
+      (first_index..last_index).each do |i|
+        size += layout_axis[:sizes][i]
+        size += gap if i < last_index
+      end
+
+      size
+    end
+
+    private
+
+    def parse_tracks(definition, axis)
+      tokens = tokenize(definition)
+      tokens.map do |token|
+        parse_track_token(token, axis)
+      end
+    end
+
+    def tokenize(definition)
+      return [] unless definition
+
+      result = []
+      current = ''
+
+      definition.to_s.each_byte do |byte|
+        if whitespace_byte?(byte)
+          unless current.empty?
+            result << current
+            current = ''
+          end
+        else
+          current << byte.chr
+        end
+      end
+
+      result << current unless current.empty?
+      result
+    end
+
+    def parse_track_token(token, axis)
+      if integer_token?(token)
+        Track.new(:fixed, token.to_i)
+      elsif token.end_with?('%')
+        value = token[0...-1]
+        validate_numeric_token!(value, axis, token)
+        Track.new(:percent, value.to_f)
+      elsif token.end_with?('fr')
+        value = token[0...-2]
+        validate_numeric_token!(value, axis, token)
+        Track.new(:fr, value.to_f)
+      else
+        raise ArgumentError, "Invalid grid track token: '#{token}' in #{axis} definition"
+      end
+    end
+
+    def layout_axis(tracks, container_size, axis)
+      if container_size <= 0
+        raise ArgumentError, "Grid container #{axis == :columns ? 'width' : 'height'} must be positive"
+      end
+
+      sizes = compute_sizes(tracks, container_size)
+      offsets = []
+      cursor = 0
+      tracks.length.times do |i|
+        offsets << cursor
+        cursor += sizes[i]
+        cursor += gap if i < tracks.length - 1
+      end
+
+      { sizes: sizes, offsets: offsets }
+    end
+
+    def compute_sizes(tracks, container_size)
+      track_sizes = base_track_sizes(tracks, container_size)
+      distribute_leftover(track_sizes, container_size, tracks.length)
+    end
+
+    def base_track_sizes(tracks, container_size)
+      total_gaps = gap * [tracks.length - 1, 0].max
+      total_fixed = 0
+      percent_sizes = []
+      total_percent = 0.0
+      total_fr = 0.0
+
+      tracks.each_with_index do |track, idx|
+        case track.type
+        when :fixed
+          total_fixed += track.value
+        when :percent
+          size = container_size * (track.value / 100.0)
+          percent_sizes[idx] = size
+          total_percent += size
+        when :fr
+          total_fr += track.value
+        end
+      end
+
+      free_space = container_size - total_fixed - total_percent - total_gaps
+      free_space = 0 if free_space < 0
+
+      tracks.each_with_index.map do |track, idx|
+        case track.type
+        when :fixed
+          track.value
+        when :percent
+          percent_sizes[idx]
+        when :fr
+          if total_fr.zero?
+            0
+          else
+            free_space * (track.value / total_fr)
+          end
+        end
+      end
+    end
+
+    def distribute_leftover(track_sizes, container_size, track_count)
+      available = container_size - gap * [track_count - 1, 0].max
+      floored = track_sizes.map { |size| size.floor }
+      fractional = track_sizes.map.with_index do |size, index|
+        [size - size.floor, index]
+      end
+      fractional_total = fractional.sum { |(frac, _)| frac }
+
+      leftover = available - floored.sum
+      return floored if leftover <= 0 || fractional_total <= 0
+
+      order = fractional.sort do |(frac_a, idx_a), (frac_b, idx_b)|
+        if frac_a == frac_b
+          idx_a <=> idx_b
+        else
+          frac_b <=> frac_a
+        end
+      end
+
+      i = 0
+      while leftover > 0 && order.any?
+        _, idx = order[i % order.length]
+        floored[idx] += 1
+        leftover -= 1
+        i += 1
+      end
+
+      floored
+    end
+
+    def normalized_index(value, exclude_end = false)
+      index = value.to_i
+      index -= 1 if exclude_end
+      index - 1
+    end
+
+    def whitespace_byte?(byte)
+      byte == 32 || byte == 9 || byte == 10 || byte == 13
+    end
+
+    def integer_token?(value)
+      return false unless value
+      return false if value.empty?
+
+      value.each_byte.all? { |byte| digit_byte?(byte) }
+    end
+
+    def validate_numeric_token!(value, axis, token)
+      unless numeric_token?(value)
+        raise ArgumentError, "Invalid grid track token: '#{token}' in #{axis} definition"
+      end
+    end
+
+    def numeric_token?(value)
+      return false unless value
+      return false if value.empty?
+
+      dot_seen = false
+      value.each_byte do |byte|
+        if byte == 46
+          return false if dot_seen
+          dot_seen = true
+        elsif !digit_byte?(byte)
+          return false
+        end
+      end
+
+      true
+    end
+
+    def digit_byte?(byte)
+      byte >= 48 && byte <= 57
+    end
+
+
+    class Builder
+      def initialize(node, layout)
+        @node = node
+        @layout = layout
+      end
+
+      def area(name = nil, row:, col:, **attrs, &block)
+        row_range = normalize_axis(row, :rows, name)
+        col_range = normalize_axis(col, :columns, name)
+
+        validate_dimension_options!(attrs, name)
+
+        options = attrs.dup
+        options[:id] = name if name && !options.key?(:id)
+        options[:width] = Panes::Sizing.fixed(0)
+        options[:height] = Panes::Sizing.fixed(0)
+
+        area_node = @node.ui(**options, &block)
+        @node.grid_areas << AreaAssignment.new(area_node, row_range, col_range)
+        area_node
+      end
+
+      private
+
+      def normalize_axis(value, axis, area_name)
+        count = @layout.track_count(axis)
+        axis_label = single_axis_label(axis)
+        plural_label = plural_axis_label(axis)
+
+        range = case value
+                when :all
+                  if count.zero?
+                    raise ArgumentError, "Grid area #{area_label(area_name)} cannot use :all for #{axis_label} when no #{plural_label} are defined"
+                  end
+                  1..count
+                when Range
+                  build_range(value, axis_label, area_name)
+                when Integer
+                  build_range(value..value, axis_label, area_name)
+                else
+                  raise ArgumentError, "Grid area #{area_label(area_name)} #{axis_label} must be an Integer, Range, or :all"
+                end
+
+        ensure_bounds(range, count, axis_label, plural_label, area_name)
+      end
+
+      def build_range(value, axis_label, area_name)
+        first = coerce_index(value.begin, axis_label, area_name)
+        last_value = value.end
+        last_value = last_value - 1 if value.exclude_end?
+        last = coerce_index(last_value, axis_label, area_name)
+
+        if last < first
+          raise ArgumentError, "Grid area #{area_label(area_name)} #{axis_label} range must be increasing"
+        end
+
+        first..last
+      end
+
+      def ensure_bounds(range, count, axis_label, plural_label, area_name)
+        if range.begin < 1
+          raise ArgumentError, "Grid area #{area_label(area_name)} #{axis_label} indices must be >= 1"
+        end
+
+        if range.end > count
+          raise ArgumentError, "Grid area #{area_label(area_name)} refers to #{axis_label} #{range.end} but only #{count} #{plural_label} are defined"
+        end
+
+        range
+      end
+
+      def validate_dimension_options!(attrs, area_name)
+        if attrs.key?(:width) || attrs.key?(:height)
+          raise ArgumentError, "Grid area #{area_label(area_name)} derives its size from the grid definition"
+        end
+      end
+
+      def coerce_index(value, axis_label, area_name)
+        Integer(value)
+      rescue ArgumentError, TypeError
+        raise ArgumentError, "Grid area #{area_label(area_name)} #{axis_label} index must be numeric"
+      end
+
+      def area_label(name)
+        name ? name.inspect : '(anonymous)'
+      end
+
+      def single_axis_label(axis)
+        axis == :rows ? 'row' : 'col'
+      end
+
+      def plural_axis_label(axis)
+        axis == :rows ? 'rows' : 'columns'
+      end
+    end
+  end
+end

--- a/mrblib/node.rb
+++ b/mrblib/node.rb
@@ -10,6 +10,7 @@ module Panes
     attr_accessor :x, :y, :width, :height
     attr_accessor :direction
     attr_accessor :bg_color, :fg_color
+    attr_accessor :grid_layout, :grid_areas, :grid_position, :grid_state
 
     def initialize(
       id: nil, parent: nil, children: [],
@@ -39,6 +40,11 @@ module Panes
         @padding[:left]   += 1 if @border[:left]
       end
 
+      @grid_layout = nil
+      @grid_areas = []
+      @grid_position = nil
+      @grid_state = {}
+
       @w_sizing = Sizing.build(width)
       if fixed_width?
         @width = min_width
@@ -56,6 +62,10 @@ module Panes
 
     def inline_text?
       type == :inline_text
+    end
+
+    def grid_layout?
+      !!grid_layout
     end
 
     def parent=(node)
@@ -79,6 +89,26 @@ module Panes
         result += [0, (children.length-1) * child_gap].max
       end
       result
+    end
+
+    def grid(columns:, rows:, gap: 0, **_grid_options, &block)
+      unless block_given?
+        raise ArgumentError, 'grid requires a block'
+      end
+
+      if grid_layout?
+        label = id ? id.inspect : '(anonymous)'
+        raise ArgumentError, "Grid already defined for #{label}"
+      end
+
+      @grid_layout = GridLayout.new(columns: columns, rows: rows, gap: gap)
+      @grid_areas = []
+      @grid_state = {}
+
+      builder = GridLayout::Builder.new(self, grid_layout)
+      builder.instance_eval(&block)
+
+      self
     end
 
     def ui(id: nil, width: nil, height: nil, padding: [0], child_gap: 0, border: nil, direction: :left_right, bg_color: nil, fg_color: nil, &block)
@@ -109,19 +139,21 @@ module Panes
         node.height += node.total_height_spacing
       end
 
-      if node_parent.fit_width?
-        if node_parent.left_right?
-          node_parent.width += node.min_width
-        else
-          node_parent.width = [node_parent.width, node.min_width].max
+      unless node_parent.grid_layout?
+        if node_parent.fit_width?
+          if node_parent.left_right?
+            node_parent.width += node.min_width
+          else
+            node_parent.width = [node_parent.width, node.min_width].max
+          end
         end
-      end
 
-      if node_parent.fit_height?
-        if node_parent.left_right?
-          node_parent.height = [node_parent.height, node.min_height].max
-        else
-          node_parent.height += node.min_height
+        if node_parent.fit_height?
+          if node_parent.left_right?
+            node_parent.height = [node_parent.height, node.min_height].max
+          else
+            node_parent.height += node.min_height
+          end
         end
       end
 
@@ -164,8 +196,10 @@ module Panes
         node.width += node.total_width_spacing
       end
 
-      if node_parent.fit_width?
-        node_parent.width += node.min_width
+      unless node_parent.grid_layout?
+        if node_parent.fit_width?
+          node_parent.width += node.min_width
+        end
       end
 
       # Fit Height Adjustment - (unused)
@@ -173,8 +207,10 @@ module Panes
         node.height += node.total_height_spacing
       end
 
-      if node_parent.fit_height?
-        node_parent.height = [node_parent.height, node.min_height].max
+      unless node_parent.grid_layout?
+        if node_parent.fit_height?
+          node_parent.height = [node_parent.height, node.min_height].max
+        end
       end
 
       node

--- a/mrblib/panes.rb
+++ b/mrblib/panes.rb
@@ -27,37 +27,43 @@ module Panes
     alias :build :ui
 
     def grow_width_containers(node)
-      growables, sized = node.children.partition(&:grown_width?)
+      unless node.grid_layout?
+        growables, sized = node.children.partition(&:grown_width?)
 
-      if node.left_right?
-        if growables.any?
-          extra_width = [0, node.width - node.total_width_spacing - sized.sum(&:width)].max
-          current_sizes = growables.map do |node|
-            {
-              current: node.width,
-              min: node.min_width,
-              max: node.max_width
-            }
-          end
-
-          Calculations
-            .water_fill_distribution(current_sizes, extra_width)
-            .each.with_index do |extra, i|
-              growables[i].width += extra
+        if node.left_right?
+          if growables.any?
+            extra_width = [0, node.width - node.total_width_spacing - sized.sum(&:width)].max
+            current_sizes = growables.map do |node|
+              {
+                current: node.width,
+                min: node.min_width,
+                max: node.max_width
+              }
             end
-        end
-      else
-        if growables.any?
-          max_width = [node.width - node.total_width_spacing, 0].max
-          growables.each do |child|
-            child.width = [max_width, child.max_width].min
+
+            Calculations
+              .water_fill_distribution(current_sizes, extra_width)
+              .each.with_index do |extra, i|
+                growables[i].width += extra
+              end
+          end
+        else
+          if growables.any?
+            max_width = [node.width - node.total_width_spacing, 0].max
+            growables.each do |child|
+              child.width = [max_width, child.max_width].min
+            end
+          end
+
+          parent = node.parent
+          if parent&.fit_width?
+            parent.width = [parent.width, node.width].max
           end
         end
+      end
 
-        parent = node.parent
-        if parent&.fit_width?
-          parent.width = [parent.width, node.width].max
-        end
+      if node.grid_layout?
+        assign_grid_columns(node)
       end
 
       node.children.each do |child|
@@ -78,37 +84,43 @@ module Panes
     end
 
     def grow_height_containers(node)
-      growables, sized = node.children.reject(&:text?).partition(&:grown_height?)
+      unless node.grid_layout?
+        growables, sized = node.children.reject(&:text?).partition(&:grown_height?)
 
-      if node.left_right?
-        if growables.any?
-          max_height = [node.height - node.total_height_spacing, 0].max
-          growables.each do |child|
-            child.height = [max_height, child.max_height].min
-          end
-        end
-
-        parent = node.parent
-        if parent&.fit_height?
-          parent.height = [parent.height, node.height].max
-        end
-      else
-        if growables.any?
-          extra_height = [0, node.height - node.total_height_spacing - sized.sum(&:height)].max
-          current_sizes = growables.map do |node|
-            {
-              current: node.height,
-              min: node.min_height,
-              max: node.max_height
-            }
-          end
-
-          Calculations
-            .water_fill_distribution(current_sizes, extra_height)
-            .each.with_index do |extra, i|
-              growables[i].height += extra
+        if node.left_right?
+          if growables.any?
+            max_height = [node.height - node.total_height_spacing, 0].max
+            growables.each do |child|
+              child.height = [max_height, child.max_height].min
             end
+          end
+
+          parent = node.parent
+          if parent&.fit_height?
+            parent.height = [parent.height, node.height].max
+          end
+        else
+          if growables.any?
+            extra_height = [0, node.height - node.total_height_spacing - sized.sum(&:height)].max
+            current_sizes = growables.map do |node|
+              {
+                current: node.height,
+                min: node.min_height,
+                max: node.max_height
+              }
+            end
+
+            Calculations
+              .water_fill_distribution(current_sizes, extra_height)
+              .each.with_index do |extra, i|
+                growables[i].height += extra
+              end
+          end
         end
+      end
+
+      if node.grid_layout?
+        assign_grid_rows(node)
       end
 
       node.children.each do |child|
@@ -116,21 +128,88 @@ module Panes
       end
     end
 
+    def assign_grid_columns(node)
+      label = grid_container_label(node)
+      ensure_grid_children!(node, label)
+
+      inner_width = node.width - node.padding[:left] - node.padding[:right]
+      if inner_width <= 0
+        raise ArgumentError, "Grid container #{label} must have positive width"
+      end
+
+      layout = node.grid_layout.layout_columns(inner_width)
+      node.grid_state[:columns] = layout
+
+      node.grid_areas.each do |area|
+        child = area.node
+        child.width = node.grid_layout.span_size(layout, area.col_range)
+        child.w_sizing = Sizing.fixed(child.width)
+        position = child.grid_position || { x: 0, y: 0 }
+        position[:x] = node.grid_layout.axis_start(layout, area.col_range.begin - 1)
+        child.grid_position = position
+      end
+    end
+
+    def assign_grid_rows(node)
+      label = grid_container_label(node)
+      ensure_grid_children!(node, label)
+
+      inner_height = node.height - node.padding[:top] - node.padding[:bottom]
+      if inner_height <= 0
+        raise ArgumentError, "Grid container #{label} must have positive height"
+      end
+
+      assign_grid_columns(node) unless node.grid_state[:columns]
+
+      layout = node.grid_layout.layout_rows(inner_height)
+      node.grid_state[:rows] = layout
+
+      node.grid_areas.each do |area|
+        child = area.node
+        child.height = node.grid_layout.span_size(layout, area.row_range)
+        child.h_sizing = Sizing.fixed(child.height)
+        position = child.grid_position || { x: 0, y: 0 }
+        position[:y] = node.grid_layout.axis_start(layout, area.row_range.begin - 1)
+        child.grid_position = position
+      end
+    end
+
+    def ensure_grid_children!(node, label)
+      grid_nodes = node.grid_areas.map(&:node)
+      unless (node.children - grid_nodes).empty?
+        raise ArgumentError, "All children of grid container #{label} must be declared via area"
+      end
+    end
+
+    def grid_container_label(node)
+      node.id ? node.id.inspect : '(anonymous)'
+    end
+
     def set_positions(node, offset_x = 0, offset_y = 0)
       node.x = offset_x
       node.y = offset_y
 
-      node.children.each do |child|
-        set_positions(
-          child,
-          offset_x + node.padding[:left],
-          offset_y + node.padding[:top]
-        )
+      child_offset_x = offset_x + node.padding[:left]
+      child_offset_y = offset_y + node.padding[:top]
 
-        if node.left_right?
-          offset_x += child.width + node.child_gap
-        else
-          offset_y += child.height + node.child_gap
+      if node.grid_layout?
+        node.children.each do |child|
+          position = child.grid_position || { x: 0, y: 0 }
+          set_positions(
+            child,
+            child_offset_x + position[:x],
+            child_offset_y + position[:y]
+          )
+        end
+      else
+        node.children.each do |child|
+          set_positions(child, child_offset_x, child_offset_y)
+
+          if node.left_right?
+            child_offset_x += child.width + node.child_gap
+          else
+            child_offset_y += child.height + node.child_gap
+          end
         end
       end
     end

--- a/test/layout/grid.rb
+++ b/test/layout/grid.rb
@@ -1,0 +1,220 @@
+class TestGridLayout < MTest::Unit::TestCase
+  def test_fixed_tracks_position_children
+    layout = Panes.init(width: 40, height: 20)
+
+    commands = layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+      ui(id: 'grid', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        grid columns: '10 10', rows: '5 5' do
+          area :top_left, row: 1, col: 1 do
+            text 'TL', id: 'tl'
+          end
+
+          area :bottom_right, row: 2, col: 2 do
+            text 'BR', id: 'br'
+          end
+        end
+      end
+    end
+
+    top = find_command(commands, :top_left, :rectangle)
+    bottom = find_command(commands, :bottom_right, :rectangle)
+    tl_text = find_command(commands, 'tl', :text)
+    br_text = find_command(commands, 'br', :text)
+
+    assert_equal({ x: 0, y: 0, width: 10, height: 5 }, top[:bounding_box])
+    assert_equal({ x: 10, y: 5, width: 10, height: 5 }, bottom[:bounding_box])
+    assert_equal({ x: 0, y: 0, width: 2, height: 1 }, tl_text[:bounding_box])
+    assert_equal({ x: 10, y: 5, width: 2, height: 1 }, br_text[:bounding_box])
+  end
+
+  def test_percent_and_fractional_tracks
+    layout = Panes.init(width: 100, height: 40)
+
+    commands = layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+      ui(id: 'metrics', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        grid columns: '10 20% 1fr', rows: '3 1fr 3' do
+          area :fixed, row: 1, col: 1 do
+            text 'A'
+          end
+
+          area :mixed, row: 2, col: 2..3 do
+            text 'Wide'
+          end
+        end
+      end
+    end
+
+    fixed = find_command(commands, :fixed, :rectangle)
+    mixed = find_command(commands, :mixed, :rectangle)
+
+    assert_equal({ x: 0, y: 0, width: 10, height: 3 }, fixed[:bounding_box])
+    assert_equal({ x: 10, y: 3, width: 90, height: 34 }, mixed[:bounding_box])
+  end
+
+  def test_spanning_with_gap
+    layout = Panes.init(width: 50, height: 20)
+
+    commands = layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+      ui(id: 'gap', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        grid columns: '10 10 10', rows: '5 5', gap: 1 do
+          area :header, row: 1, col: :all do
+            text 'Header'
+          end
+
+          area :span, row: 2, col: 2..3 do
+            text 'Body'
+          end
+        end
+      end
+    end
+
+    header = find_command(commands, :header, :rectangle)
+    span = find_command(commands, :span, :rectangle)
+
+    assert_equal({ x: 0, y: 0, width: 32, height: 5 }, header[:bounding_box])
+    assert_equal({ x: 11, y: 6, width: 21, height: 5 }, span[:bounding_box])
+  end
+
+  def test_all_shorthand
+    layout = Panes.init(width: 30, height: 10)
+
+    commands = layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+      ui(id: 'full', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        grid columns: '5 5', rows: '2 2' do
+          area :all_area, row: :all, col: :all do
+            text 'Cover'
+          end
+        end
+      end
+    end
+
+    area = find_command(commands, :all_area, :rectangle)
+    assert_equal({ x: 0, y: 0, width: 10, height: 4 }, area[:bounding_box])
+  end
+
+  def test_nested_grid_coordinates
+    layout = Panes.init(width: 60, height: 20)
+
+    commands = layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+      ui(id: 'outer', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        grid columns: '20 20', rows: '10 10' do
+          area :content, row: 2, col: 2 do
+            grid columns: '1fr 1fr', rows: '5 5' do
+              area :left, row: 1..2, col: 1 do
+                text 'Left'
+              end
+
+              area :right, row: 1..2, col: 2 do
+                text 'Right'
+              end
+            end
+          end
+        end
+      end
+    end
+
+    content = find_command(commands, :content, :rectangle)
+    left = find_command(commands, :left, :rectangle)
+    right = find_command(commands, :right, :rectangle)
+
+    assert_equal({ x: 20, y: 10, width: 20, height: 10 }, content[:bounding_box])
+    assert_equal({ x: 20, y: 10, width: 10, height: 10 }, left[:bounding_box])
+    assert_equal({ x: 30, y: 10, width: 10, height: 10 }, right[:bounding_box])
+  end
+
+  def test_invalid_track_token_raises
+    layout = Panes.init(width: 20, height: 20)
+
+    assert_raise(ArgumentError) do
+      layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        ui(width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+          grid columns: 'foo', rows: '1' do
+            area :broken, row: 1, col: 1
+          end
+        end
+      end
+    end
+  end
+
+  def test_out_of_range_indices_raise
+    layout = Panes.init(width: 20, height: 20)
+
+    assert_raise(ArgumentError) do
+      layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        ui(width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+          grid columns: '5 5', rows: '5 5' do
+            area :invalid, row: 3, col: 1
+          end
+        end
+      end
+    end
+  end
+
+  def test_empty_track_definition_raises
+    layout = Panes.init(width: 20, height: 20)
+
+    assert_raise(ArgumentError) do
+      layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        ui(width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+          grid columns: '', rows: '1' do
+            area :invalid, row: 1, col: 1
+          end
+        end
+      end
+    end
+  end
+
+  def test_area_cannot_define_explicit_dimensions
+    layout = Panes.init(width: 20, height: 20)
+
+    assert_raise(ArgumentError) do
+      layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        ui(width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+          grid columns: '5', rows: '5' do
+            area :invalid, row: 1, col: 1, width: 1 do
+              text 'bad'
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_grid_rejects_non_area_children
+    layout = Panes.init(width: 20, height: 20)
+
+    assert_raise(ArgumentError) do
+      layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        ui(width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+          grid columns: '5', rows: '5' do
+            area :only, row: 1, col: 1
+          end
+
+          text 'outside'
+        end
+      end
+    end
+  end
+
+  def test_grid_requires_positive_inner_dimensions
+    layout = Panes.init(width: 10, height: 10)
+
+    assert_raise(ArgumentError) do
+      layout.build(id: 'root', width: Panes::Sizing.grow, height: Panes::Sizing.grow) do
+        ui(width: Panes::Sizing.fixed(4), height: Panes::Sizing.fixed(4), padding: [3]) do
+          grid columns: '1', rows: '1' do
+            area :small, row: 1, col: 1
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def find_command(commands, id, type)
+    commands.find { |cmd| cmd[:id] == id && cmd[:type] == type }
+  end
+end
+
+MTest::Unit.new.run


### PR DESCRIPTION
## Summary
- add a grid layout helper with area placement, column/row sizing, nesting support, and explicit error handling
- document the DSL in the README and include an interactive example under `examples/grid.rb`
- cover the feature with an exhaustive suite of layout specs

## Testing
- `bin/test test/layout/grid.rb`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e88e70e08332952819008798c470)